### PR TITLE
Add url hashchange event to handle todo-list filter

### DIFF
--- a/src/components/todo-app/todo-app.tsx
+++ b/src/components/todo-app/todo-app.tsx
@@ -9,6 +9,17 @@ const ENTER_KEY = 13;
 export class TodoApp {
 
 	@State() todos: Todo[] = [];
+	@State() filter: string = "/";
+	get filteredTodos(): Todo[] {
+		switch(this.filter) {
+			case "/active": 
+				return this.todos.filter(todo=>!todo.completed)
+			case "/completed":
+				return this.todos.filter(todo=>todo.completed)
+			default:
+				return this.todos;
+		}
+	}
 
 	private onKeyUp(event: KeyboardEvent) {
 		if (event.keyCode == ENTER_KEY) {
@@ -16,6 +27,12 @@ export class TodoApp {
 			this.todos = this.todos.concat(new Todo(input.value));
 			input.value = '';
 		}
+	}
+
+	@Listen('window:hashchange')
+	hashChanged(e:HashChangeEvent) {
+		// VERY "NAIVE WAY" TO EXTRACT HASH FRAGMENT FROM CURR URL
+		this.filter = (e.newURL && e.newURL.split("#")[1]) || "/";
 	}
 
 	@Listen('clearCompleted')
@@ -57,7 +74,7 @@ export class TodoApp {
 					<input class="new-todo" placeholder="What needs to be done?" autoComplete="true"
 						onKeyUp={event => this.onKeyUp(event)} />
 				</header>
-				<todo-list todos={this.todos}></todo-list>
+				<todo-list todos={this.filteredTodos}></todo-list>
 				{this.todos.length > 0 ? <todo-footer todos={this.todos}></todo-footer> : null}
 			</section>
 		);

--- a/src/components/todo-app/todo-app.tsx
+++ b/src/components/todo-app/todo-app.tsx
@@ -75,7 +75,7 @@ export class TodoApp {
 						onKeyUp={event => this.onKeyUp(event)} />
 				</header>
 				<todo-list todos={this.filteredTodos}></todo-list>
-				{this.todos.length > 0 ? <todo-footer todos={this.todos}></todo-footer> : null}
+				{this.todos.length > 0 ? <todo-footer todos={this.todos} curr={this.filter}></todo-footer> : null}
 			</section>
 		);
 	}

--- a/src/components/todo-footer/todo-footer.tsx
+++ b/src/components/todo-footer/todo-footer.tsx
@@ -7,6 +7,7 @@ import { Todo } from '../../todo';
 export class Footer {
 
 	@Prop() todos: Todo[];
+	@Prop() curr: string;
 
 	@Event() clearCompleted: EventEmitter;
 
@@ -19,19 +20,21 @@ export class Footer {
 		);
 	}
 
+
 	render() {
+		const linkSelected = (hash:string, text:string) => <a href={'#'+hash} class={{'selected':hash===this.curr}} >{text}</a>
 		return (
 			<footer class="footer">
 				{this.renderTodoCount()}
 				<ul class="filters">
 					<li>
-						<a class="selected" href="#/">All</a>
+						{ linkSelected("/","All") }
 					</li>
 					<li>
-						<a href="#/active">Active</a>
+						{ linkSelected("/active","Active") }
 					</li>
 					<li>
-						<a href="#/completed">Completed</a>
+						{ linkSelected("/completed","Completed") }
 					</li>
 				</ul>
 				<button class="clear-completed" onClick={(ev) => this.clearCompleted.emit()}>Clear completed</button>


### PR DESCRIPTION
I try to add the missing behaviour of the list filtering based on url change.
I've done it in a "naive way" handling the window:hashchange event to read the hash fragment from url and set it to the filter. 
Then I use a simple getter to evaluate the filteredTodos to pass data to todo-list component + reflect the current selected link into the todo-footer.
Hope you can accept this contribution.
