### PR TITLE
change todo-item to have @Prop completed

### DIFF
--- a/src/components/todo-item/todo-item.tsx
+++ b/src/components/todo-item/todo-item.tsx
@@ -13,6 +13,8 @@ export class TodoItem {
 
 	@Prop() todo: Todo;
 
+	@Prop() completed: boolean;
+
 	@Event() todoDeleted: EventEmitter;
 
 	@Event() todoEdited: EventEmitter;
@@ -22,9 +24,9 @@ export class TodoItem {
 	render() {
 		if (this.todo) {
 			return (
-				<li class={{ completed: this.todo.completed, editing: this.editing }}>
+				<li class={{ completed: this.completed, editing: this.editing }}>
 					<div class="view">
-						<input class="toggle" type="checkbox" checked={this.todo.completed}
+						<input class="toggle" type="checkbox" checked={this.completed}
 							onChange={event => this.toggle(event)} />
 						<label onClick={event => this.edit(event)}>{this.todo.title}</label>
 						<button class="destroy" onClick={event => this.todoDeleted.emit(this.todo)}></button>
@@ -41,6 +43,7 @@ export class TodoItem {
 	private toggle(event: Event) {
 		event.preventDefault();
 		this.todo.completed = !this.todo.completed;
+		this.completed = this.todo.completed;
 		this.todoEdited.emit(this.todo);
 	}
 

--- a/src/components/todo-list/todo-list.tsx
+++ b/src/components/todo-list/todo-list.tsx
@@ -13,7 +13,7 @@ export class TodoList {
 				<input id="toggle-all" class="toggle-all" type="checkbox" />
 				<label htmlFor="toggle-all">Mark all as complete</label>
 				<ul class="todo-list">
-					{this.todos.map(todo => <todo-item todo={todo}></todo-item>)}
+					{this.todos.map(todo => <todo-item todo={todo} completed={todo.completed}></todo-item>)}
 				</ul>
 			</section>
 		);


### PR DESCRIPTION
I _think_ I have fixed your issue with the todo.completed and the checkbox action not updating the li class to strike or unstrike the item. Complex Prop objects and their properties are likely not compared to trigger a render update(). However, simply setting a @Prop completed will trigger updates. Thanks for putting this together, its the project I selected to start in learning StencilJS. It's promising!